### PR TITLE
Update Skip song button to say "Skip" instead of "Remove"

### DIFF
--- a/src/modules/owlet/commands/play.ts
+++ b/src/modules/owlet/commands/play.ts
@@ -161,7 +161,7 @@ function generateButtons(id: string) {
   buttons.push(
     new ButtonBuilder()
       .setCustomId(`track-rm_${id}`)
-      .setLabel("Remove")
+      .setLabel("Skip")
       .setStyle(ButtonStyle.Danger)
   );
 


### PR DESCRIPTION
This is better UX, because a button with "Remove" exists on other messages, and that button removes the message and does not act on the underlying data.