### PR TITLE
🐛 Double level up due to mismatched conditions

### DIFF
--- a/bot/src/modules/level/events/messageCreate.ts
+++ b/bot/src/modules/level/events/messageCreate.ts
@@ -1,11 +1,10 @@
 import { state } from "@app";
-import { connectOrCreate } from "@lib/prisma/connectOrCreate";
 import { Event } from "@structs/event";
 import { localState } from "..";
 import { calculateLevelFromXP } from "../lib/calculateLevelFromXP";
 import { getRandomXP } from "../lib/getRandomXP";
-import { notify } from "../lib/notify";
-import { addRoles, getRoles } from "../lib/roles";
+import { levelUp } from "../lib/levelUp";
+import { getLevelData } from "../lib/getLevelData";
 
 export default Event({
   name: "messageCreate",
@@ -24,42 +23,24 @@ export default Event({
     const id = `${msg.guildId}-${msg.author.id}`;
     const lastTimeout = localState.timeout.get(id);
     if (lastTimeout && Date.now() - 60 * 1000 < lastTimeout) return;
-
+    localState.timeout.set(id, Date.now());
 
     // Find or create level data for the user.
-    let levelData = await state.db.level.findUnique({
-      where: {
-        userId_guildId: { guildId: msg.guild.id, userId: msg.author.id },
-      },
-    });
-
-    if (!levelData)
-      levelData = await state.db.level.create({
-        data: {
-          user: connectOrCreate(msg.author.id),
-          guild: connectOrCreate(msg.guild.id),
-        },
-      });
+    const levelData = await getLevelData(msg.guild.id, msg.author.id);
 
     // Calculate the old and new levels.
     const oldLevel = calculateLevelFromXP(levelData.experience);
-    const toAdd = getRandomXP(guildConfig.levelModifier)
+    const toAdd = getRandomXP(guildConfig.levelModifier);
     const newExperience = levelData.experience + toAdd;
     const newLevel = calculateLevelFromXP(newExperience);
 
-    // If the user has leveled up, add the roles and notify the user.
-    if (newLevel.level > oldLevel.level) {
-      const roles = await getRoles(msg, newLevel);
-      await addRoles(msg, roles);
-      await notify(msg, guildConfig, newLevel, roles);
-    }
-
-    await state.db.level.update({
-      where: { userId_guildId: { guildId: msg.guild.id, userId: msg.author.id } },
-      data: { experience: newExperience },
-    });
-
-    localState.timeout.set(id, Date.now());
+    // Update the user's experience and level.
+    await Promise.all([
+      state.db.level.update({
+        where: { userId_guildId: { guildId: msg.guild.id, userId: msg.author.id } },
+        data: { experience: newExperience },
+      }),
+      levelUp(msg, guildConfig, newLevel, oldLevel),
+    ]);
   },
-
 });

--- a/bot/src/modules/level/events/messageCreate.ts
+++ b/bot/src/modules/level/events/messageCreate.ts
@@ -47,7 +47,7 @@ export default Event({
     current.currentXP += toAdd;
 
     // If the user has leveled up, add the roles and notify the user.
-    if (current.currentXP >= localState.levelArray[current.level].xp) {
+    if (current.currentXP >= current.levelXP) {
       current.level += 1;
 
       const roles = await getRoles(msg, current);

--- a/bot/src/modules/level/lib/calculateLevelFromXP.ts
+++ b/bot/src/modules/level/lib/calculateLevelFromXP.ts
@@ -12,7 +12,7 @@ export function calculateLevelFromXP(exp: number): CalculatedLevel {
   let currentLevel;
 
   for (let index = 0; index < localState.levelArray.length; index++) {
-    if (localState.levelArray[index].total < exp) continue;
+    if (exp >= localState.levelArray[index].total) continue;
     currentLevel = index === 0 ? 0 : index - 1;
     break;
   }

--- a/bot/src/modules/level/lib/getLevelData.ts
+++ b/bot/src/modules/level/lib/getLevelData.ts
@@ -1,0 +1,20 @@
+import { state } from "@app";
+import { connectOrCreate } from "@lib/prisma/connectOrCreate";
+
+export async function getLevelData(guildId: string, userId: string) {
+  let levelData = await state.db.level.findUnique({
+    where: {
+      userId_guildId: { guildId, userId },
+    },
+  });
+
+  if (!levelData)
+    levelData = await state.db.level.create({
+      data: {
+        user: connectOrCreate(userId),
+        guild: connectOrCreate(guildId),
+      },
+    });
+
+  return levelData;
+}

--- a/bot/src/modules/level/lib/levelUp.ts
+++ b/bot/src/modules/level/lib/levelUp.ts
@@ -1,0 +1,15 @@
+import { Message } from "discord.js";
+import { CalculatedLevel } from "./calculateLevelFromXP";
+import { notify } from "./notify";
+import { getRoles, addRoles } from "./roles";
+import { Guild } from "@prisma/client";
+
+export async function levelUp(msg: Message<true>, guildConfig: Guild, newLevel: CalculatedLevel, oldLevel: CalculatedLevel | undefined = undefined) {
+  if (oldLevel && newLevel.level <= oldLevel.level) return;
+
+  const roles = await getRoles(msg, newLevel);
+  await Promise.all([
+    addRoles(msg, roles),
+    notify(msg, guildConfig, newLevel, roles),
+  ]);
+}


### PR DESCRIPTION
calculateLevelFromXP.ts has a not-equals condition while the level up logic in messageCreate.ts has a with-equals condition, this PR changes both to be greater than or equal